### PR TITLE
Update rebuilder.py

### DIFF
--- a/isrm/rebuilder.py
+++ b/isrm/rebuilder.py
@@ -48,6 +48,8 @@ class Reader(object):
                                  username=CONF.openstack.user,
                                  password=CONF.openstack.password,
                                  tenant_name=CONF.openstack.tenant)
+        keystone = client.Client(endpoint=CONF.openstack.auth_url,
+                                 token=keystone.auth_token)
         self.tenants = dict([(t.name, t.id) for t in keystone.tenants.list()])
         return nova_cli.Client(2, session=sess)
 


### PR DESCRIPTION
In out case ISRM services work on FUEL master node. This node does not have access to 'public' network. That's why keystone should be created by token, not by user/pass. Now when we request tenant list, public url will be used.